### PR TITLE
チェットへのメッセージ追加の頻度制限

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+__pycache__
 .runtimeconfig.json
 gs
 logs

--- a/pi/src/alert.py
+++ b/pi/src/alert.py
@@ -1,0 +1,68 @@
+from enum import Enum, auto
+from time import time
+
+
+class Status(Enum):
+    OK = auto()
+    NG = auto()
+
+
+class Alert:
+    # 何回NGが続いたらアラートを出すか
+    _continuous_ng_cout_threshold = 3
+    # 前回の送信より何秒以上経っていたら出すか
+    _min_alert_interval_sec = 60 * 60
+    last_status = None
+    last_ng_time = None
+    last_ok_time = None
+    last_alert_time = None
+    ok_to_ng = False
+    ng_to_ok = False
+    continuous_ng_count = 0
+
+    def __init__(self,
+                 continuous_ng_threshold=None,
+                 min_alert_interval_sec=None) -> None:
+        self._min_alert_interval_sec = min_alert_interval_sec or self._min_alert_interval_sec
+        self._continuous_ng_cout_threshold = continuous_ng_threshold or self._continuous_ng_cout_threshold
+
+    def __str__(self):
+        return f'''last_status: {self.last_status}\
+        last_ng_time: {self.last_ng_time}\
+        last_alert_time: {self.last_alert_time}\
+        continuous_ng_count: {self.continuous_ng_count}\
+        needs_alert: {self.needs_alert()}'''
+
+    def update(self, status: Status) -> None:
+        if self.last_status is Status['OK'] and status is Status['NG']:
+            self.ok_to_ng = True
+            self.ng_to_ok = False
+            self.continuous_ng_count = 1
+        elif self.last_status is Status['NG'] and status is Status['OK']:
+            self.ok_to_ng = True
+            self.ng_to_ok = False
+
+        if self.last_status is Status['NG'] and status is Status['NG']:
+            self.continuous_ng_count += 1
+
+        if status is Status['OK']:
+            self.continuous_ng_count = 0
+            self.last_ok_time = time()
+        elif status is Status['NG']:
+            self.last_ng_time = time()
+
+        self.last_status = status
+
+    def needs_alert(self) -> bool:
+        if self.continuous_ng_count <= self._continuous_ng_cout_threshold:
+            return False
+
+        if self.last_alert_time is None:
+            self.last_alert_time = time()
+            return True
+
+        if time() - self.last_alert_time <= self._min_alert_interval_sec:
+            return False
+
+        self.last_alert_time = time()
+        return True

--- a/pi/src/run.py
+++ b/pi/src/run.py
@@ -5,6 +5,7 @@ from config import (CO2SIGNALS_SENSOR_READ_INTERVAL_SECONDS,
                     CO2SIGNALS_API_LOCATION,
                     CO2SIGNALS_API_TOKEN)
 from datetime import datetime
+from enum import Enum, auto
 from gpiozero import LED
 from time import sleep, time
 import mh_z19
@@ -17,6 +18,41 @@ leds = {
     'yellow': LED(3),
     'red': LED(4)
 }
+
+class Status(Enum):
+    OK = auto()
+    NG = auto()
+
+class Alert:
+    _last_status = None
+    _last_ng_time = None
+    _last_ok_time = None
+    _ok_to_ng = False
+    _ng_to_ok = False
+    _continuous_ng_count = 0
+
+    def __init__(self, alert_interval_sec=60):
+        self._alert_interval_sec = alert_interval_sec
+
+    def check(self, status):
+        if _last_status is Status['OK'] and status is Status['NG']:
+            _ok_to_ng = True
+            _ng_to_ok = False
+            _continuous_ng_count = 1
+        else if _last_status is Status['NG'] and status is Status['OK']:
+            _ok_to_ng = True
+            _ng_to_ok = False
+            _continuous_ng_count = 0
+
+        if _last_status is Status['NG'] and status is Status['NG']:
+            _continuous_ng_count += 1
+
+        if status is Status['OK']:
+            self._last_ok = datetime.now()
+        else if status is Status['NG']:
+            self._last_ng = datetime.now()
+
+        _last_status = status
 
 def on_single_led(on_name):
     for name, led in leds.items():


### PR DESCRIPTION
1500ppm超えると毎分メッセージが来てスパムなので、連続3回以上かつ、1時間に1回にメッセージ送信を制限する。

前回送信日時の保存をDBで行うと面倒なので、常時起動のラズパイ側で対応した